### PR TITLE
feat: Add semantic release

### DIFF
--- a/.github/workflows/backend.yml
+++ b/.github/workflows/backend.yml
@@ -3,7 +3,7 @@ name: Backend CI
 on: [push, pull_request]
 
 jobs:
-  build:
+  test:
     runs-on: ubuntu-latest
     defaults:
       run:
@@ -21,7 +21,28 @@ jobs:
         run: |
           python -m py_compile app/main.py
           pytest -q
-      - name: Build Docker image
-        run: |
-          docker build -t personal-website-backend .
 
+  build:
+    needs: test
+    runs-on: ubuntu-latest
+    defaults:
+      run:
+        working-directory: BE
+    steps:
+      - uses: actions/checkout@v3
+      - name: Build Docker image
+        run: docker build -t personal-website-backend .
+
+  release:
+    needs: build
+    if: github.event_name == 'pull_request' && github.event.action == 'closed' && github.event.pull_request.merged == true && github.event.pull_request.base.ref == 'main'
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v3
+      - uses: actions/setup-node@v3
+        with:
+          node-version: 18
+      - name: Run semantic-release
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        run: npx semantic-release

--- a/.github/workflows/backend.yml
+++ b/.github/workflows/backend.yml
@@ -22,7 +22,7 @@ jobs:
           python -m py_compile app/main.py
           pytest -q
 
-  build:
+  package:
     needs: test
     runs-on: ubuntu-latest
     defaults:
@@ -34,7 +34,7 @@ jobs:
         run: docker build -t personal-website-backend .
 
   release:
-    needs: build
+    needs: package
     if: github.event_name == 'pull_request' && github.event.action == 'closed' && github.event.pull_request.merged == true && github.event.pull_request.base.ref == 'main'
     runs-on: ubuntu-latest
     steps:

--- a/.github/workflows/backend.yml
+++ b/.github/workflows/backend.yml
@@ -1,6 +1,6 @@
 name: Backend CI
 
-on: [push, pull_request]
+on: [push]
 
 jobs:
   test:


### PR DESCRIPTION
## Summary
- split CI workflow into separate jobs for tests, docker build and release
- run semantic-release job only after a PR merges into `main`