### PR TITLE
chore: Configure pre-commit hooks

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -1,0 +1,8 @@
+repos:
+  - repo: https://github.com/pre-commit/pre-commit-hooks
+    rev: v4.4.0
+    hooks:
+      - id: check-docstring-first
+      - id: end-of-file-fixer
+      - id: requirements-txt-fixer
+      - id: trailing-whitespace

--- a/BE/requirements.txt
+++ b/BE/requirements.txt
@@ -2,3 +2,4 @@ fastapi
 uvicorn
 pytest
 requests
+pre-commit

--- a/README.md
+++ b/README.md
@@ -6,8 +6,13 @@ This repository now includes a minimal FastAPI backend located in the `BE` direc
 
 ### Running the development server
 
+Before installing dependencies, create and activate a Python virtual
+environment:
+
 ```zsh
 cd BE
+python -m venv .venv
+source .venv/bin/activate
 pip install -r requirements.txt
 uvicorn app.main:app --reload
 ```
@@ -25,3 +30,16 @@ pytest -q
 cd BE
 docker build -t personal-website-backend .
 ```
+
+### Setting up pre-commit
+
+The repository uses [pre-commit](https://pre-commit.com/) to run simple
+formatting checks. After installing the dependencies listed in
+`BE/requirements.txt`, install the git hooks and run them:
+
+```zsh
+pre-commit install
+pre-commit run --all-files
+```
+
+

--- a/README.md
+++ b/README.md
@@ -13,7 +13,17 @@ environment:
 cd BE
 python -m venv .venv
 source .venv/bin/activate
+```
+
+Install dependencies
+
+```zsh
 pip install -r requirements.txt
+```
+
+Run the development server
+
+```zsh
 uvicorn app.main:app --reload
 ```
 
@@ -41,5 +51,3 @@ formatting checks. After installing the dependencies listed in
 pre-commit install
 pre-commit run --all-files
 ```
-
-


### PR DESCRIPTION
## Summary
- add pre-commit dependency
- document running the hooks
- configure standard pre-commit hooks
- document virtualenv setup

## Testing
- `pre-commit run --files README.md BE/requirements.txt .pre-commit-config.yaml` *(fails: command not found)*
- `pip install -r BE/requirements.txt` *(fails: no route to host)*