### PR TITLE
Fix backend semantic release trigger

### DIFF
--- a/.github/workflows/backend.yml
+++ b/.github/workflows/backend.yml
@@ -1,6 +1,12 @@
 name: Backend CI
 
-on: [push]
+on:
+  push:
+    branches:
+      - main
+  pull_request:
+    branches:
+      - main
 
 jobs:
   test:
@@ -35,7 +41,7 @@ jobs:
 
   release:
     needs: package
-    if: github.event_name == 'pull_request' && github.event.action == 'closed' && github.event.pull_request.merged == true && github.event.pull_request.base.ref == 'main'
+    if: github.event_name == 'push' && github.ref == 'refs/heads/main'
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v3


### PR DESCRIPTION
## Summary
- run workflow on push to main and on pull_request to main
- restrict release step to push events on main branch
- document branch filter for pull_request

## Testing
- `pre-commit run --files .github/workflows/backend.yml` *(fails: couldn't fetch hooks)*
- `pytest -q`