### PR TITLE
fix: Add semantic-release configuration

### DIFF
--- a/.releaserc.json
+++ b/.releaserc.json
@@ -1,0 +1,4 @@
+{
+  "branches": ["main"],
+  "tagFormat": "v${version}"
+}


### PR DESCRIPTION
## Summary
- configure semantic-release to release from `main` branch

## Testing
- `pre-commit` *(fails: couldn't access pre-commit-hooks repo)*
- `pytest`