### PR TITLE
feat: require Google Sign-In

### DIFF
--- a/FE/public/index.html
+++ b/FE/public/index.html
@@ -7,5 +7,7 @@
   </head>
   <body>
     <div id="root"></div>
+    <script src="https://www.gstatic.com/firebasejs/9.6.11/firebase-app-compat.js"></script>
+    <script src="https://www.gstatic.com/firebasejs/9.6.11/firebase-auth-compat.js"></script>
   </body>
 </html>

--- a/FE/src/App.js
+++ b/FE/src/App.js
@@ -1,7 +1,34 @@
+import { useEffect, useState } from 'react';
+import { auth } from './firebase';
+
 function App() {
+  const [user, setUser] = useState(null);
+
+  useEffect(() => {
+    const unsubscribe = auth.onAuthStateChanged((u) => setUser(u));
+    auth.getRedirectResult().catch((err) => console.error(err));
+    return unsubscribe;
+  }, []);
+
+  const signIn = () => {
+    const provider = new window.firebase.auth.GoogleAuthProvider();
+    auth.signInWithRedirect(provider).catch((err) => console.error(err));
+  };
+
+  const signOut = () => auth.signOut();
+
+  if (!user) {
+    return (
+      <div className="App">
+        <button onClick={signIn}>Sign In with Google</button>
+      </div>
+    );
+  }
+
   return (
     <div className="App">
       <h1>Hello from React</h1>
+      <button onClick={signOut}>Sign Out</button>
     </div>
   );
 }

--- a/FE/src/firebase.js
+++ b/FE/src/firebase.js
@@ -1,0 +1,11 @@
+const firebaseConfig = {
+    apiKey: "AIzaSyB69Eoy5mc6CME4IvrOKtp2SK4b7P1_Qpk",
+    authDomain: "januario-website.firebaseapp.com",
+};
+
+// Initialize Firebase using the global firebase from CDN
+if (!window.firebase.apps?.length) {
+  window.firebase.initializeApp(firebaseConfig);
+}
+
+export const auth = window.firebase.auth();

--- a/FE/src/index.js
+++ b/FE/src/index.js
@@ -2,6 +2,7 @@ import React from 'react';
 import ReactDOM from 'react-dom/client';
 import App from './App';
 import './index.css';
+import './firebase';
 
 const root = ReactDOM.createRoot(document.getElementById('root'));
 root.render(


### PR DESCRIPTION
## Summary
- add Firebase script tags
- add Firebase init and auth helpers
- require Google authentication before accessing the FE
- switch sign-in method to use redirect flow

## Testing
- `pre-commit run --files FE/package-lock.json FE/src/App.js` *(fails: unable to fetch pre-commit hooks)*
- `npm test -- --watchAll=false --passWithNoTests`
